### PR TITLE
Support Smart-Home-Interface Part 3: Definition objects

### DIFF
--- a/luxtronik/shi/common.py
+++ b/luxtronik/shi/common.py
@@ -7,6 +7,66 @@ import logging
 
 LOGGER = logging.getLogger("Luxtronik.SmartHomeInterface")
 
+###############################################################################
+# Version methods
+###############################################################################
+
+def parse_version(version):
+    """
+    Parse a version string into a tuple with exactly 4 integers.
+    The individual numbers correspond to `major.minor.patch.build`.
+    A given tuple of integers is expanded or reduced to 4 integers.
+
+    Examples:
+        "1"         -> (1, 0, 0, 0)
+        "2.1"       -> (2, 1, 0, 0)
+        "3.2.1"     -> (3, 2, 1, 0)
+        "1.2.3.4"   -> (1, 2, 3, 4)
+        "1.2.3.4.5" -> (1, 2, 3, 4)   # extra parts are ignored
+        "a.b"       -> None
+
+    Args:
+        version (str | tuple[int, ...]): Version string or version as tuple.
+
+    Returns:
+        tuple[int, int, int, int] | None: Parsed version tuple, or None if invalid.
+    """
+    if isinstance(version, tuple) and all(type(p) is int for p in version):
+        return (version + (0, 0, 0, 0))[:4]
+    elif isinstance(version, str):
+        parts = version.strip().split(".")
+        if not parts or any(not p.isdigit() for p in parts):
+            return None
+        nums = [int(p) for p in parts]
+        nums = (nums + [0, 0, 0, 0])[:4]
+        return tuple(nums)
+    else:
+        return None
+
+
+def version_in_range(version, since=None, until=None):
+    """
+    Check whether a version is within the specified range of `[since..until]`.
+    If an argument is None, the corresponding check is skipped.
+
+    Args:
+        version (tuple[int, ...] | None): The version to check.
+            If None, returns True.
+        since (tuple[int, ...] | None): Lower bound (inclusive).
+            If None, no lower bound is applied.
+        until (tuple[int, ...] | None): Upper bound (inclusive).
+            If None, no upper bound is applied.
+
+    Returns:
+        bool: True if version is within the range, False otherwise.
+    """
+    if version is None:
+        return True
+    if since is not None and version < since:
+        return False
+    if until is not None and version > until:
+        return False
+    return True
 
 ###############################################################################
 # Smart home telegrams

--- a/luxtronik/shi/constants.py
+++ b/luxtronik/shi/constants.py
@@ -8,9 +8,15 @@ LUXTRONIK_DEFAULT_MODBUS_PORT: Final = 502
 # Default timeout (in seconds) for Modbus operations
 LUXTRONIK_DEFAULT_MODBUS_TIMEOUT: Final = 30
 
+# Default offset for the input or holding indices
+LUXTRONIK_DEFAULT_DEFINITION_OFFSET: Final = 10000
+
 # Waiting time (in seconds) after writing the holdings
 # to give the controller time to recalculate values, etc.
 LUXTRONIK_WAIT_TIME_AFTER_HOLDING_WRITE: Final = 1
+
+# Since version 3.92.0, all unavailable data fields have been returning this value
+LUXTRONIK_VALUE_FUNCTION_NOT_AVAILABLE: Final = 32767
 
 # First Luxtronik firmware version that supports the Smart Home Interface (SHI)
 LUXTRONIK_FIRST_VERSION_WITH_SHI: Final = (3, 90, 1, 0)

--- a/luxtronik/shi/definitions.py
+++ b/luxtronik/shi/definitions.py
@@ -1,0 +1,569 @@
+"""
+The metadata (`index`, `count`, ...) for a field (`Base`, `SelectionBase`)
+is stored as a definition object. For ease of use, all definitions
+of one type (`input`, `holding`, ...) are provided as a sorted list of objects.
+This usually contains only predefined definitions (generated out of
+`HOLDINGS_DEFINITIONS_LIST` or `INPUTS_DEFINITIONS_LIST`),
+but can be expanded by the user.
+"""
+
+from luxtronik.datatypes import Unknown
+from luxtronik.shi.constants import (
+    LUXTRONIK_DEFAULT_DEFINITION_OFFSET,
+    LUXTRONIK_VALUE_FUNCTION_NOT_AVAILABLE
+)
+from luxtronik.shi.common import (
+    LOGGER,
+    parse_version
+)
+
+
+###############################################################################
+# LuxtronikDefinition
+###############################################################################
+
+class LuxtronikDefinition:
+    """
+    Metadata container for a Luxtronik data field.
+
+    Also provides a method to create a related field object.
+    """
+
+    DEFAULT_DATA = {
+        "index": -1,
+        "count": 1,
+        "type": Unknown,
+        "writeable": False,
+        "names": [],
+        "since": "",
+        "until": "",
+        "description": "",
+    }
+
+    def __init__(self, data_dict, type_name, offset=LUXTRONIK_DEFAULT_DEFINITION_OFFSET):
+        """
+        Initialize a definition from a data-dictionary.
+
+        Args:
+            data_dict (dict): Definition values. Missing keys are filled with defaults.
+            type_name (str): The type name e.g. 'holding', 'input', ... .
+            offset (str): Offset of the address from the specified index.
+                (Default: LUXTRONIK_DEFAULT_DEFINITION_OFFSET)
+
+        Notes:
+            - Only 'index' is strictly required within the `data_dict`.
+            - The class may only be created with dictionaries
+              that have been checked for correctness using pytest.
+              This eliminates the need for type tests here.
+        """
+        try:
+            data_dict = self.DEFAULT_DATA | data_dict
+            index = int(data_dict["index"])
+            self._valid = index >= 0
+            self._index = index if self._valid else 0
+            self._count = int(data_dict["count"])
+            self._data_type = data_dict["type"]
+            self._writeable = bool(data_dict["writeable"])
+            names = data_dict["names"]
+            if not isinstance(names, list):
+                names = [str(names)]
+            names = [str(name).strip() for name in names if str(name).strip()]
+            if not names:
+                names = ["_invalid_"]
+            self._names = names
+            self._aliases = []
+            since = str(data_dict["since"])
+            self._since = parse_version(since)
+            until = str(data_dict["until"])
+            self._until = parse_version(until)
+            self._description = str(data_dict["description"])
+            self._type_name = type_name.lower()
+            self._valid &= len(self._type_name) > 0
+            self._offset = int(offset)
+            self._addr = self._offset + self._index
+        except Exception as e:
+            self._valid = False
+            self._index = 0
+            LOGGER.error(f"Failed to create LuxtronikDefinition: '{e}' with {data_dict}")
+
+    @classmethod
+    def unknown(cls, index, type_name, offset=LUXTRONIK_DEFAULT_DEFINITION_OFFSET):
+        """
+        Create an "unknown" definition.
+
+        Args:
+            index (int): The register index of the "unknown" definition.
+            type_name (str): The type name e.g. 'holding', 'input', ... .
+            offset (str): Offset of the address from the specified index.
+                (Default: LUXTRONIK_DEFAULT_DEFINITION_OFFSET)
+
+        Returns:
+            LuxtronikDefinition: A definition marked as unknown.
+        """
+        return cls({
+            "index": index,
+            "names": [f"unknown_{type_name.lower()}_{index}"]
+        }, type_name, offset)
+
+    def __bool__(self):
+        """Return True if the definition is valid."""
+        return self._valid
+
+    def __repr__(self):
+        return f"(name={self.name}, data_type={self.data_type}," \
+            + f" index={self.index}, count={self.count})"
+
+    @property
+    def valid(self):
+        return self._valid
+
+    @property
+    def type_name(self):
+        "Returns the type name (e.g. 'holding', 'input', ...)."
+        return self._type_name
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def offset(self):
+        return self._offset
+
+    @property
+    def addr(self):
+        return self._addr
+
+    @property
+    def count(self):
+        "Returns the assigned number of used bytes/words."
+        return self._count
+
+    @property
+    def data_type(self):
+        return self._data_type
+
+    @property
+    def writeable(self):
+        return self._writeable
+
+    @property
+    def names(self):
+        return self._names
+
+    @property
+    def aliases(self):
+        return self._aliases
+
+    @property
+    def name(self):
+        "Returns the preferred name."
+        return self._names[0]
+
+    @property
+    def since(self):
+        return self._since
+
+    @property
+    def until(self):
+        return self._until
+
+    def create_field(self):
+        """
+        Create a data field instance from this definition.
+
+        Returns:
+            Base | None: Field instance or None if invalid.
+        """
+        return self.data_type(self.name, self.writeable) if self.valid else None
+
+
+###############################################################################
+# LuxtronikDefinitionsDictionary
+###############################################################################
+
+class LuxtronikDefinitionsDictionary:
+    """
+    Dictionary of definitions that can be searched by index, name, or aliases.
+
+    To use aliases, they must first be registered here (locally =
+    only valid for this dictionary) or directly in the `LuxtronikDefinitionsList`
+    (globally = valid for all newly created dictionaries).
+
+    This class is intended to speed up the lookup of definitions.
+    Dictionaries are used instead of searching through a list of definitions
+    one by one to find the one you are looking for.
+    """
+
+    def __init__(self):
+        self._index_dict = {}
+        self._name_dict = {}
+        self._alias_dict = {}
+
+    def __getitem__(self, name_or_idx):
+        return self.get(name_or_idx)
+
+    def __contains__(self, name_or_idx):
+        return self._get(name_or_idx) is not None
+
+    def _add_alias(self, definition, alias):
+        """
+        Register a single alias that references the given definition.
+
+        Args:
+            definition (LuxtronikDefinition): Definition that the alias should map to.
+            alias (Hashable): Alias to register (str will be normalized).
+        """
+        alias = alias.lower() if isinstance(alias, str) else alias
+        self._alias_dict[alias] = definition
+
+    def register_alias(self, def_name_or_idx, alias):
+        """
+        Register an alias (locally) that references a definition specified by
+        name, index, or the definition object.
+
+        Args:
+            def_name_or_idx (str | int | LuxtronikDefinition):
+                Name, index, or definition to alias.
+            alias (Hashable): Alias key to register (str will be normalized).
+
+        Returns:
+            LuxtronikDefinition | None: The resolved definition
+                when registration succeeded, otherwise None.
+        """
+        if alias is None:
+            return None
+        # look-up definition
+        if isinstance(def_name_or_idx, LuxtronikDefinition):
+            definition = self.get(def_name_or_idx.name)
+        else:
+            definition = self.get(def_name_or_idx)
+        if definition is None:
+            return None
+        self._add_alias(definition, alias)
+        return definition
+
+    def add(self, definition, alias=None):
+        """
+        Add a definition to internal lookup tables and register its aliases.
+        Existing entries will be overwritten.
+
+        Args:
+            definition (LuxtronikDefinition): Definition to add.
+            alias (Hashable): Optional additional alias to register for this definition.
+        """
+        # Add to indices-dictionary
+        self._index_dict[definition.index] = definition
+
+        # Add to name-dictionary
+        # Unique names has already been ensured by the pytest
+        for name in definition.names:
+            self._name_dict[name.lower()] = definition
+
+        # Add to alias-dictionary
+        for a in definition.aliases:
+            self._add_alias(definition, a)
+        if alias is not None:
+            self._add_alias(definition, alias)
+
+    def get(self, name_or_idx, default=None):
+        """
+        Retrieve a definition by name or index.
+
+        Args:
+            name_or_idx (str | int): Definition name or register index.
+            default (LuxtronikDefinition): Definition to return if the searched one is not found.
+
+        Returns:
+            LuxtronikDefinition | None: The matching definition, or None if not found.
+
+        Note:
+            If multiple definitions added for the same index/name, the last added takes precedence.
+        """
+        d = self._get(name_or_idx)
+        if d is None:
+            LOGGER.warning(f"Definition for '{name_or_idx}' not found", )
+        return d if d is not None else default
+
+    def _get(self, name_or_idx):
+        """
+        Retrieve a definition by name or index.
+
+        Args:
+            name_or_idx (str | int): Definition name or register index.
+
+        Returns:
+            LuxtronikDefinition | None: The matching definition, or None if not found.
+
+        Note:
+            If multiple definitions added for the same index/name, the last added takes precedence.
+        """
+        d = self._get_definition_by_alias(name_or_idx)
+        if d is None:
+            if isinstance(name_or_idx, int):
+                d = self._get_definition_by_idx(name_or_idx)
+                if d is None:
+                    # search in alias-dict again with the index converted to a string
+                    d = self._get_definition_by_alias(str(name_or_idx))
+            if isinstance(name_or_idx, str):
+                try:
+                    # Numbers are not allowed as names, so it could be an index as string
+                    idx_from_str = int(name_or_idx)
+                    d = self._get_definition_by_idx(idx_from_str)
+                    if d is None:
+                        # search in alias-dict again with the string converted to an index
+                        d = self._get_definition_by_alias(str(name_or_idx))
+                except ValueError:
+                    d = self._get_definition_by_name(name_or_idx)
+        return d
+
+    def _get_definition_by_idx(self, idx):
+        """
+        Retrieve a definition by its index.
+
+        Args:
+            idx (int): Register index.
+
+        Returns:
+            LuxtronikDefinition | None: The matching definition, or None if not found.
+
+        Note:
+            If multiple definitions added for the same index, the last added takes precedence.
+        """
+        return self._index_dict.get(idx, None)
+
+    def _get_definition_by_name(self, name):
+        """
+        Retrieve a definition by its name (case-insensitive).
+
+        Args:
+            name (str): Definition name.
+
+        Returns:
+            LuxtronikDefinition | None: The matching definition, or None if not found.
+
+        Note:
+            If multiple definitions added for the same name, the last added takes precedence.
+        """
+        definition = self._name_dict.get(name.lower(), None)
+        if definition is not None and definition.valid and name.lower() != definition.name.lower():
+            LOGGER.warning(f"'{name}' is outdated! Use '{definition.name}' instead.")
+        return definition
+
+    def _get_definition_by_alias(self, alias):
+        """
+        Retrieve a definition by its alias (case-insensitive when using strings).
+
+        Args:
+            alias (Hashable): Alias for a definition.
+
+        Returns:
+            LuxtronikDefinition | None: The matching definition, or None if not found.
+
+        Note:
+            If multiple definitions added for the same alias, the last added takes precedence.
+        """
+        alias = alias.lower() if isinstance(alias, str) else alias
+        return self._alias_dict.get(alias, None)
+
+
+###############################################################################
+# LuxtronikDefinitionsList
+###############################################################################
+
+class LuxtronikDefinitionsList:
+    """
+    Container for Luxtronik definitions.
+
+    Provides lookup by index, name or alias.
+
+    To use aliases, they must first be registered here (globally = valid for
+    all newly created dictionaries) or within the `LuxtronikDefinitionsDictionary`
+    (locally = only valid for that dictionary).
+    """
+
+    def __init__(self, definitions_list, name, offset=LUXTRONIK_DEFAULT_DEFINITION_OFFSET):
+        """
+        Initialize the (by index sorted) definitions list.
+
+        Args:
+            definitions_list (list[dict]): Raw definition entries as list of data-dictionaries.
+            name (str): Name related to this type of definitions (e.g. "holding")
+            offset (int): Offset applied to register indices.
+                (Default: LUXTRONIK_DEFAULT_DEFINITION_OFFSET)
+
+        Notes on the definitions_list:
+            - Must be sorted by ascending index
+            - Each version may contain only one entry per register
+            - If there exists more than one definition per index,
+              only the last one can be found using indices/names
+            - The value of count must always be greater than or equal to 1
+            - All names should be unique
+        """
+        self._name = name
+        self._offset = offset
+        # sorted list of all definitions
+        self._definitions = []
+        self._lookup = LuxtronikDefinitionsDictionary()
+
+        # Add definition objects only for valid items.
+        # The correct sorting has already been ensured by the pytest
+        for item in definitions_list:
+            d = LuxtronikDefinition(item, name, offset)
+            self._add(d)
+
+    def __getitem__(self, name_or_idx):
+        return self.get(name_or_idx)
+
+    def __len__(self):
+        return len(self._definitions)
+
+    def __iter__(self):
+        return iter(self._definitions)
+
+    def __repr__(self):
+        defs = [repr(d) for d in self._definitions]
+        return f"({self.name}, {self.offset}, {' ,'.join(defs)})"
+
+    def create_unknown_definition(self, index):
+        """
+        Create an "unknown" definition.
+
+        Args:
+            index (int): The register index of the "unknown" definition.
+
+        Returns:
+            LuxtronikDefinition: A definition marked as unknown.
+        """
+        return LuxtronikDefinition.unknown(index, self._name, self._offset)
+
+    def register_alias(self, def_name_or_idx, alias):
+        """
+        Register an alias (globally) that references a definition specified by
+        name, index, or the definition object.
+
+        Args:
+            def_name_or_idx (str | int | LuxtronikDefinition):
+                Name, index, or definition to alias.
+            alias (any): (Hashable) Alias key to register (str will be normalized).
+
+        Returns:
+            LuxtronikDefinition | None: The resolved definition
+                when registration succeeded, otherwise None.
+        """
+        # "local" registration to be able to find the definition again
+        definition = self._lookup.register_alias(def_name_or_idx, alias)
+        # "global" registration that is used in newly created definition-dictionaries
+        if definition is not None:
+            definition.aliases.append(alias)
+        return definition
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def offset(self):
+        return self._offset
+
+    def get(self, name_or_idx, default=None):
+        """
+        Retrieve a definition by name or index.
+
+        Args:
+            name_or_idx (str | int): Definition name or register index.
+
+        Returns:
+            LuxtronikDefinition | None: The matching definition, or None if not found.
+
+        Note:
+            If multiple definitions added for the same index/name, the last added takes precedence.
+        """
+        return self._lookup.get(name_or_idx, default)
+
+    def _add(self, definition):
+        """
+        Add a valid definition to the internal dictionaries
+
+        Args:
+            definition (LuxtronikDefinition): Definition to add
+        """
+        if definition.valid:
+            self._definitions.append(definition)
+            self._lookup.add(definition)
+
+    def add(self, data_dict):
+        """
+        Add a custom (valid) definition
+
+        Args:
+            data_dict (dict): Data for the definition to add
+
+        Returns:
+            LuxtronikDefinition | None: The created definition or None if not valid
+
+        Note:
+            If multiple definitions added for the same index/name, the last added takes precedence.
+        """
+        definition = LuxtronikDefinition(data_dict, self._name, self._offset)
+        self._add(definition)
+        self._definitions.sort(key=lambda item: item.index)
+        return definition if definition.valid else None
+
+
+###############################################################################
+# Definition-Field-Pair methods
+###############################################################################
+
+def get_data_arr(definition, field):
+    """
+    Normalize the field's data to a list of the correct size.
+
+    Args:
+        definition (LuxtronikDefinition): Meta-data of the field.
+        field (Base): Field object that contains data to get.
+
+    Returns:
+        list[int] | None: List of length `definition.count`, or None if insufficient.
+    """
+    data = field.raw
+    if not isinstance(data, list):
+        data = [data]
+    data = data[:definition.count]
+    return data if len(data) == definition.count else None
+
+def check_data(definition, field):
+    """
+    Validate that the field contains sufficient raw data.
+
+    Args:
+        definition (LuxtronikDefinition): Meta-data of the field.
+        field (Base): Field object that contains the data to check.
+
+    Returns:
+        bool: True if valid, False otherwise.
+    """
+    return get_data_arr(definition, field) is not None
+
+def integrate_data(definition, field, raw_data, data_offset=-1):
+    """
+    Integrate raw values from a data array into the field.
+
+    Args:
+        definition (LuxtronikDefinition): Meta-data of the field.
+        field (Base): Field object where to integrate the data.
+        raw_data (list): Source array of bytes/words.
+        data_offset (int): Optional offset. Defaults to `definition.index`.
+    """
+    data_offset = data_offset if data_offset >= 0 else definition.index
+    # Use the information of the definition to extract the raw-value
+    if (data_offset + definition.count - 1) >= len(raw_data):
+        raw = None
+    elif definition.count == 1:
+        raw = raw_data[data_offset]
+        raw = raw if raw != LUXTRONIK_VALUE_FUNCTION_NOT_AVAILABLE else None
+    else:
+        raw = raw_data[data_offset : data_offset + definition.count]
+        raw = raw if len(raw) == definition.count and \
+            not any(data == LUXTRONIK_VALUE_FUNCTION_NOT_AVAILABLE for data in raw) else None
+    field.raw = raw

--- a/tests/shi/test_common.py
+++ b/tests/shi/test_common.py
@@ -1,4 +1,8 @@
+import pytest
+
 from luxtronik.shi.common import (
+    parse_version,
+    version_in_range,
     LuxtronikSmartHomeReadTelegram,
     LuxtronikSmartHomeWriteTelegram,
 )
@@ -6,6 +10,55 @@ from luxtronik.shi.common import (
 ###############################################################################
 # Tests
 ###############################################################################
+
+class TestVersion:
+
+    @pytest.mark.parametrize(
+        "string, version",
+        [
+            ("1",           (1, 0, 0, 0)),
+            ("2.1",         (2, 1, 0, 0)),
+            ("3.2.1",       (3, 2, 1, 0)),
+            ("1.2.3.4",     (1, 2, 3, 4)),
+            ("1.2.3.4.5",   (1, 2, 3, 4)),
+            ("a.b",         None),
+            ("hello",       None),
+            ("foo.bar",     None),
+            ("1_2",         None),
+            ("3 4",         None),
+            (None,          None),
+            ((1, 0, 0, 4),  (1, 0, 0, 4)),
+            ((2, 1, 3),     (2, 1, 3, 0)),
+            ((3, 2),        (3, 2, 0, 0)),
+            ((5,),          (5, 0, 0, 0)),
+            ((),            (0, 0, 0, 0)),
+            ((3, "foo", 2), None),
+        ]
+    )
+    def test_parse(self, string, version):
+        parsed = parse_version(string)
+        assert parsed == version
+
+    @pytest.mark.parametrize(
+        "version, since, until, in_range",
+        [
+            (None,   None,   None,         True),
+            ((1, 2), None,   None,         True),
+            (None,   (5, 4), (2, 1),       True),
+            ((2, 4), (1, 3), None,         True),
+            ((2, 4), (5, 1), None,         False),
+            ((2, 4), None,   (2, 3, 9),    False),
+            ((2, 4), None,   (2, 4, 0, 1), True),
+            ((5, 6), (5, 6), (5, 6),       True),
+            ((5, 6), (5, 7), (5, 6),       False),
+            ((5, 6), (5, 6), (5, 5),       False),
+            ((3, 7), (2, 8), (4, 6),       True),
+        ]
+    )
+    def test_in_range(self, version, since, until, in_range):
+        result = version_in_range(version, since, until)
+        assert result == in_range
+
 
 class TestReadTelegram:
 

--- a/tests/shi/test_definition_list.py
+++ b/tests/shi/test_definition_list.py
@@ -3,6 +3,7 @@ import re
 from luxtronik.datatypes import Base
 from luxtronik.definitions.holdings import HOLDINGS_DEFINITIONS_LIST
 from luxtronik.definitions.inputs import INPUTS_DEFINITIONS_LIST
+from luxtronik.shi.common import parse_version
 
 KEY_IDX = "index"
 KEY_COUNT = "count"
@@ -14,7 +15,7 @@ KEY_UNTIL = "until"
 KEY_DESC = "description"
 
 
-class RunTestDefinitions:
+class RunTestDefinitionList:
 
     # override this
     definitions = None
@@ -27,15 +28,19 @@ class RunTestDefinitions:
 
     def test_structure(self):
         for definition in self.definitions:
+
+            # index
             assert KEY_IDX in definition, \
                 f"{KEY_IDX} not defined: {definition}"
             assert isinstance(definition[KEY_IDX], int), \
                 f"{KEY_IDX} must be of type 'int': {definition}"
 
+            # count
             if KEY_COUNT in definition:
                 assert isinstance(definition[KEY_COUNT], int), \
                     f"{KEY_COUNT} must be of type 'int': {definition}"
 
+            # names
             if KEY_NAMES in definition:
                 assert isinstance(definition[KEY_NAMES], list) \
                         or isinstance(definition[KEY_NAMES], str), \
@@ -45,22 +50,27 @@ class RunTestDefinitions:
                         assert isinstance(name, str), f"Entry of {KEY_NAMES} " \
                             f"must be of type 'int': {definition}"
 
+            # data_type
             if KEY_TYPE in definition:
                 assert issubclass(definition[KEY_TYPE], Base), \
                     f"{KEY_TYPE} must be inherit from 'Base': {definition}"
 
+            # writeable
             if KEY_WRT in definition:
                 assert isinstance(definition[KEY_WRT], bool), \
                     f"{KEY_WRT} must be of type 'bool': {definition}"
 
+            # since
             if KEY_SINCE in definition:
                 assert isinstance(definition[KEY_SINCE], str), \
                     f"{KEY_SINCE} must be of type 'str': {definition}"
 
+            # until
             if KEY_UNTIL in definition:
                 assert isinstance(definition[KEY_UNTIL], str), \
                     f"{KEY_UNTIL} must be of type 'str': {definition}"
 
+            # description
             if KEY_DESC in definition:
                 assert isinstance(definition[KEY_DESC], str), \
                     f"{KEY_DESC} must be of type 'str': {definition}"
@@ -99,6 +109,11 @@ class RunTestDefinitions:
                     f"The name may only contain a-z0-9_ {definition}"
                 assert sanitized != "", \
                     f"Name must not be empty. {definition}"
+                try:
+                    int(name)
+                    assert False, "Name must not be a number."
+                except Exception:
+                    pass
 
     def test_name_unique(self):
         length = len(self.definitions)
@@ -123,15 +138,31 @@ class RunTestDefinitions:
                 assert data_type is not None, \
                     f"Type must be set: {definition}"
 
+    def test_since(self):
+        for definition in self.definitions:
+            if KEY_SINCE in definition:
+                since = definition.get(KEY_SINCE, "")
+                parsed = parse_version(since)
+                assert parsed is not None, \
+                    f"Since must be a valid version instead of {since}: {definition}"
+
+    def test_until(self):
+        for definition in self.definitions:
+            if KEY_UNTIL in definition:
+                until = definition.get(KEY_UNTIL, "")
+                parsed = parse_version(until)
+                assert parsed is not None, \
+                    f"Until must be a valid version instead of {until}: {definition}"
+
 ###############################################################################
 # Tests
 ###############################################################################
 
-class TestHoldingsDefinitions(RunTestDefinitions):
+class TestHoldingsDefinitionList(RunTestDefinitionList):
 
     definitions = HOLDINGS_DEFINITIONS_LIST
 
 
-class TestInputsDefinitions(RunTestDefinitions):
+class TestInputsDefinitionList(RunTestDefinitionList):
 
     definitions = INPUTS_DEFINITIONS_LIST

--- a/tests/shi/test_definitions.py
+++ b/tests/shi/test_definitions.py
@@ -1,0 +1,488 @@
+from luxtronik.datatypes import Base, Unknown
+from luxtronik.shi.constants import LUXTRONIK_VALUE_FUNCTION_NOT_AVAILABLE
+from luxtronik.shi.definitions import (
+    LuxtronikDefinition,
+    LuxtronikDefinitionsDictionary,
+    LuxtronikDefinitionsList,
+    get_data_arr,
+    check_data,
+    integrate_data,
+)
+
+###############################################################################
+# Tests
+###############################################################################
+
+class TestDefinition:
+
+    TEST_DATA = {
+        'index': 4,
+        'count': 3,
+        'type': Base,
+        'writeable': True,
+        'names': ['test1', 'test2'],
+        'since': '1.1',
+        'until': '3.16.7',
+        'description': 'foo',
+    }
+    DEFAULT_DATA = LuxtronikDefinition.DEFAULT_DATA
+    TEST_FIELD = Base('TestField', True)
+    TEST_ARRAY = [13, 10, 14, 12, 18, 11, 16, 15, 17, 19]
+
+    def test_init(self):
+        definition = LuxtronikDefinition(self.TEST_DATA, 'Bar', 20)
+
+        names = self.TEST_DATA['names']
+        assert definition.index == self.TEST_DATA['index']
+        assert definition.count == self.TEST_DATA['count']
+        assert definition.data_type == self.TEST_DATA['type']
+        assert definition.writeable == self.TEST_DATA['writeable']
+        assert definition.names == names
+        assert definition.name == names[0]
+        assert definition.valid
+        assert definition
+        assert definition.type_name == 'bar'
+        assert definition.offset == 20
+        assert definition.addr == 20 + self.TEST_DATA['index']
+        assert definition.aliases == []
+        assert definition.since == (1, 1, 0, 0)
+        assert definition.until == (3, 16, 7, 0)
+
+        definition = LuxtronikDefinition({
+            'index': 10,
+            'names': []
+        }, 'Bar', 20)
+        assert definition.valid
+        assert definition.index == 10
+        assert definition.name == '_invalid_'
+        assert not definition.writeable
+
+    def test_init_unknown(self):
+        definition = LuxtronikDefinition.unknown(2, 'Foo', 30)
+
+        names = ['unknown_foo_2']
+        assert definition.index == 2
+        assert definition.count == self.DEFAULT_DATA['count']
+        assert definition.data_type == self.DEFAULT_DATA['type']
+        assert definition.writeable == self.DEFAULT_DATA['writeable']
+        assert definition.names == names
+        assert definition.name == names[0]
+        assert definition.valid
+        assert definition
+        assert definition.type_name == 'foo'
+        assert definition.offset == 30
+        assert definition.addr == 30 + 2
+        assert definition.aliases == []
+        assert definition.since is None
+        assert definition.until is None
+
+    def test_init_invalid(self):
+        # create invalid
+        definition = LuxtronikDefinition.unknown(-3, '', 10)
+        assert not definition.valid
+
+        # trigger exception
+        try:
+            definition = LuxtronikDefinition.unknown(-3, '', 'foo')
+            assert False
+        except Exception:
+            pass
+
+    def test_create_field(self):
+        # create from normal
+        definition = LuxtronikDefinition(self.TEST_DATA, 'Bar', 0)
+        field = definition.create_field()
+        assert field.name == definition.name
+        assert field.writeable == definition.writeable
+        assert type(field) is Base
+
+        # create from unknown
+        definition = LuxtronikDefinition.unknown(2, 'Foo', 30)
+        field = definition.create_field()
+        assert field.name == 'unknown_foo_2'
+        assert not field.writeable
+        assert type(field) is Unknown
+
+        # create from invalid
+        definition = LuxtronikDefinition.unknown(-3, '', 10)
+        field = definition.create_field()
+        assert field is None
+
+
+class TestDefinitionsDict:
+
+    def test_add_get(self):
+        def_dict = LuxtronikDefinitionsDictionary()
+        assert len(def_dict._index_dict) == 0
+        assert len(def_dict._name_dict) == 0
+
+        # add unknown definition
+        d1 = LuxtronikDefinition.unknown(1, 'def', 0)
+        def_dict.add(d1)
+        assert len(def_dict._index_dict) == 1
+        assert len(def_dict._name_dict) == 1
+
+        # get via index
+        assert 1 in def_dict
+        d_out = def_dict.get(1)
+        assert d1 == d_out
+
+        # get via name
+        assert 'unknown_def_1' in def_dict
+        d_out = def_dict['unknown_def_1']
+        assert d1 == d_out
+
+        # get non-existing
+        assert 2 not in def_dict
+        d_out = def_dict.get(2)
+        assert d_out is None
+
+        # get via index as string
+        assert '1' in def_dict
+        d_out = def_dict.get('1')
+        assert d1 == d_out
+
+        # add normal definition
+        d2 = LuxtronikDefinition({'index': 2, 'names': ['foo', 'bar', '4']}, 'def', 0)
+        def_dict.add(d2)
+        assert len(def_dict._index_dict) == 2
+        assert len(def_dict._name_dict) == 4
+
+        # get via name
+        assert 'FOO' in def_dict
+        d_out = def_dict.get('FOO')
+        assert d2 == d_out
+
+        # get via alternative name
+        assert 'Bar' in def_dict
+        d_out = def_dict['Bar']
+        assert d2 == d_out
+
+        # get non-existing
+        assert 'Barf' not in def_dict
+        d_out = def_dict['Barf']
+        assert d_out is None
+
+        # '4' cannot be found as name
+        assert 4 not in def_dict
+        d_out = def_dict[4]
+        assert d_out is None
+        assert '4' not in def_dict
+        d_out = def_dict['4']
+        assert d_out is None
+
+        # add unknown definition (covers previously added definition)
+        d3 = LuxtronikDefinition.unknown(1, 'def', 0)
+        def_dict.add(d3)
+        assert len(def_dict._index_dict) == 2
+        assert len(def_dict._name_dict) == 4
+
+        # get via index
+        assert 1 in def_dict
+        d_out = def_dict.get(1)
+        assert d3 == d_out
+
+    def test_alias(self):
+        def_dict = LuxtronikDefinitionsDictionary()
+
+        # add via "global"
+        d1 = LuxtronikDefinition.unknown(1, 'def', 0)
+        d1._aliases = [0xDEAD, 123456, 'Unknown_Def_2']
+        def_dict.add(d1)
+        assert len(def_dict._alias_dict) == 3
+
+        # override via "global"
+        d2 = LuxtronikDefinition.unknown(2, 'def', 0)
+        d2._aliases = [123456]
+        def_dict.add(d2, 'foo')
+        assert len(def_dict._alias_dict) == 4
+
+        # add nothing
+        d_alias = def_dict.register_alias(d2, None)
+        assert d_alias is None
+        assert len(def_dict._alias_dict) == 4
+
+        # add via method
+        d_alias = def_dict.register_alias('UNKNOWN_DEF_1', 'abc')
+        assert d_alias == d1
+        assert len(def_dict._alias_dict) == 5
+
+        # use a number as alias (which covers the original index)
+        d_alias = def_dict.register_alias(2, 1)
+        assert d_alias == d2
+        assert len(def_dict._alias_dict) == 6
+
+        # add nothing
+        d_alias = def_dict.register_alias(3, 0xAFFE)
+        assert d_alias is None
+        assert len(def_dict._alias_dict) == 6
+
+        # get via alias (which covers the original index)
+        assert 1 in def_dict
+        d_out = def_dict.get(1)
+        assert d_out == d2
+
+        # get via index
+        assert 2 in def_dict
+        d_out = def_dict.get(2)
+        assert d_out == d2
+
+        # get non-existing
+        assert 3 not in def_dict
+        d_out = def_dict.get(3)
+        assert d_out is None
+
+        # get via name
+        assert 'unknown_def_1' in def_dict
+        d_out = def_dict.get('unknown_def_1')
+        assert d_out == d1
+
+        # get via name
+        assert 'foo' in def_dict
+        d_out = def_dict.get('foo')
+        assert d_out == d2
+
+        # get via alias (which covers the original name)
+        assert 'unknown_def_2' in def_dict
+        d_out = def_dict.get('unknown_def_2')
+        assert d_out == d1
+
+        # get via string-alias
+        assert 'abc' in def_dict
+        d_out = def_dict.get('abc')
+        assert d_out == d1
+
+        # get via hex-alias
+        assert 0xDEAD in def_dict
+        d_out = def_dict.get(0xDEAD)
+        assert d_out == d1
+
+        # get via int-alias
+        assert 123456 in def_dict
+        d_out = def_dict.get(123456)
+        assert d_out == d2
+
+        # get non-existing
+        assert 0xBEEF not in def_dict
+        d_out = def_dict.get(0xBEEF)
+        assert d_out is None
+
+        # add via definition object
+        d_alias = def_dict.register_alias(d1, 'foo')
+        assert d_alias == d1
+        assert len(def_dict._alias_dict) == 6
+
+        # get via overwritten alias
+        assert 'foo' in def_dict
+        d_out = def_dict.get('foo')
+        assert d_out == d1
+
+
+class TestDefinitionsList:
+
+    def_list = [
+        {
+            "index": 5,
+            "count": 1,
+            "names": ["field_5"],
+            "type": Base,
+            "writeable": True,
+            "since": "1.1",
+            "until": "1.2",
+        },
+        {
+            "index": 7,
+            "count": 2,
+            "names": ["field_7"],
+            "type": Base,
+            "writeable": True,
+            "since": "3.1",
+        },
+        {
+            "index": 9,
+            "count": 1,
+            "names": ["field_9a"],
+            "type": Base,
+            "writeable": True,
+            "until": "1.3",
+        },
+        {
+            "index": 9,
+            "count": 2,
+            "names": ["field_9"],
+            "type": Base,
+            "writeable": True,
+            "until": "3.3",
+        },
+        {
+            "index": -1,
+            "count": 1,
+            "names": ["field_invalid"],
+            "type": Base,
+            "writeable": True,
+            "until": "3.3",
+        },
+    ]
+
+    def test_init(self):
+        definitions = LuxtronikDefinitionsList(self.def_list, 'foo', 100)
+
+        # only valid
+        assert len(definitions) == 4
+        assert definitions.name == 'foo'
+        assert definitions.offset == 100
+
+        # correct fields
+        assert definitions[5].name == "field_5"
+        assert definitions["field_7"].index == 7
+        assert definitions.get(9).addr == 109
+        assert definitions.get(9).name == "field_9"
+
+    def test_iter(self):
+        definitions = LuxtronikDefinitionsList(self.def_list, 'foo', 100)
+
+        for index, d in enumerate(definitions):
+            if index == 0:
+                assert d.index == 5
+            if index == 1:
+                assert d.index == 7
+            if index == 2:
+                assert d.index == 9
+            if index == 3:
+                assert d.index == 9
+
+    def test_create(self):
+        definitions = LuxtronikDefinitionsList(self.def_list, 'foo', 100)
+
+        # create unknown definition
+        definition = definitions.create_unknown_definition(4)
+        assert definition.index == 4
+        assert definition.count == 1
+        assert definition.data_type is Unknown
+        assert not definition.writeable
+        assert definition.names == ['unknown_foo_4']
+        assert definition.valid
+        assert definition.type_name == 'foo'
+        assert definition.offset == 100
+        assert definition.addr == 100 + 4
+        assert definition.aliases == []
+        assert definition.since is None
+        assert definition.until is None
+
+    def test_alias(self):
+        definitions = LuxtronikDefinitionsList(self.def_list, 'foo', 100)
+
+        # add alias
+        d = definitions.register_alias(5, 'bar')
+        assert d.name == 'field_5'
+
+        # get via alias
+        d = definitions[5]
+        assert d.name == 'field_5'
+
+        # add nothing
+        d = definitions.register_alias(4, 'baz')
+        assert d is None
+
+    def test_add(self):
+        definitions = LuxtronikDefinitionsList(self.def_list, 'foo', 100)
+        assert len(definitions) == 4
+
+        # add custom definition
+        added_1 = definitions.add({
+            "index": 5,
+            "count": 2,
+            "names": "baz"
+        })
+        assert len(definitions) == 5
+        assert definitions.get(5) == added_1
+        assert definitions.get("baz") == added_1
+
+        # add custom definition (partly covers previously added)
+        added_2 = definitions.add({
+            "index": 10,
+            "count": 2,
+            "names": "baz"
+        })
+        assert len(definitions) == 6
+        assert definitions.get(5) == added_1
+        assert definitions.get("baz") == added_2
+
+        # add invalid definition (not valid)
+        added_3 = definitions.add({
+            "index": -1,
+            "count": 2,
+            "names": "baz"
+        })
+        assert added_3 is None
+
+        # add invalid definition (exception)
+        added_4 = definitions.add({
+            "index": "foo",
+            "count": 2,
+            "names": 1
+        })
+        assert added_4 is None
+
+
+class TestDefinitionFieldPair:
+
+    def test_data_arr(self):
+        definition = LuxtronikDefinition.unknown(2, 'Foo', 30)
+        field = definition.create_field()
+
+        # get from value
+        definition._count = 1
+        field.raw = 5
+        arr = get_data_arr(definition, field)
+        assert arr == [5]
+        assert check_data(definition, field)
+
+        # get from array
+        definition._count = 2
+        field.raw = [7, 3]
+        arr = get_data_arr(definition, field)
+        assert arr == [7, 3]
+        assert check_data(definition, field)
+
+        # too much data
+        definition._count = 2
+        field.raw = [4, 8, 1]
+        arr = get_data_arr(definition, field)
+        assert arr == [4, 8]
+        assert check_data(definition, field)
+
+        # insufficient data
+        definition._count = 2
+        field.raw = [9]
+        arr = get_data_arr(definition, field)
+        assert arr is None
+        assert not check_data(definition, field)
+
+    def test_integrate(self):
+        definition = LuxtronikDefinition.unknown(2, 'Foo', 30)
+        field = definition.create_field()
+
+        data = [1, LUXTRONIK_VALUE_FUNCTION_NOT_AVAILABLE, 3, 4, 5, 6, 7]
+
+        # set array
+        definition._count = 2
+        integrate_data(definition, field, data)
+        assert field.raw == [3, 4]
+        integrate_data(definition, field, data, 4)
+        assert field.raw == [5, 6]
+        integrate_data(definition, field, data, 7)
+        assert field.raw is None
+        integrate_data(definition, field, data, 0)
+        assert field.raw is None
+
+        # set value
+        definition._count = 1
+        integrate_data(definition, field, data)
+        assert field.raw == 3
+        integrate_data(definition, field, data, 5)
+        assert field.raw == 6
+        integrate_data(definition, field, data, 9)
+        assert field.raw is None
+        integrate_data(definition, field, data, 1)
+        assert field.raw is None


### PR DESCRIPTION
Third pull request to gradually integrate the smart home interface. This pull request includes:

LuxtronikDefinition: Object that contains the meta-data of a field
LuxtronikDefinitionsDictionary: Dictionary to look-up a definition by name/index
LuxtronikDefinitionsList: List of LuxtronikDefinition
Pytest units for new methods and classes

Part 3 for #190