### PR TITLE
Move parse() into the cfi-interface

### DIFF
--- a/luxtronik/data_vector.py
+++ b/luxtronik/data_vector.py
@@ -38,19 +38,6 @@ class DataVector:
     def data(self):
         return self._data
 
-    def parse(self, raw_data):
-        """Parse raw data."""
-        for index, data in enumerate(raw_data):
-            entry = self._data.get(index, None)
-            if entry is not None:
-                entry.raw = data
-            else:
-                # self.logger.warning(f"Entry '%d' not in list of {self.name}", index)
-                definition = LuxtronikDefinition.unknown(index, self.name, 0)
-                field = definition.create_field()
-                field.raw = data
-                self._data.add_sorted(definition, field)
-
     def _name_lookup(self, name):
         """
         Try to find the index using the given field name.

--- a/luxtronik/data_vector.py
+++ b/luxtronik/data_vector.py
@@ -8,7 +8,6 @@ from luxtronik.constants import (
 )
 
 from luxtronik.collections import LuxtronikFieldsDictionary
-from luxtronik.definitions import LuxtronikDefinition
 
 
 LOGGER = logging.getLogger(__name__)

--- a/luxtronik/shi/vector.py
+++ b/luxtronik/shi/vector.py
@@ -292,20 +292,6 @@ class DataVectorSmartHome(DataVector):
 
 # Data and access methods #####################################################
 
-    def parse(self, raw_data):
-        """
-        Parse raw data into the corresponding fields.
-
-        Args:
-            raw_data (list[int]): List of raw register values.
-                The raw data must start at register index 0.
-        """
-        raw_len = len(raw_data)
-        for definition, field in self._data.pairs():
-            if definition.index + definition.count >= raw_len:
-                continue
-            integrate_data(definition, field, raw_data, LUXTRONIK_SHI_REGISTER_BIT_SIZE)
-
     def get(self, def_name_or_idx, default=None):
         """
         Retrieve a field by definition, name or register index.

--- a/luxtronik/shi/vector.py
+++ b/luxtronik/shi/vector.py
@@ -2,12 +2,12 @@
 import logging
 
 from luxtronik.common import version_in_range
-from luxtronik.collections import integrate_data, LuxtronikFieldsDictionary
+from luxtronik.collections import LuxtronikFieldsDictionary
 from luxtronik.data_vector import DataVector
 from luxtronik.datatypes import Base, Unknown
 from luxtronik.definitions import LuxtronikDefinition
 
-from luxtronik.shi.constants import LUXTRONIK_LATEST_SHI_VERSION, LUXTRONIK_SHI_REGISTER_BIT_SIZE
+from luxtronik.shi.constants import LUXTRONIK_LATEST_SHI_VERSION
 from luxtronik.shi.contiguous import ContiguousDataBlockList
 
 

--- a/tests/cfi/test_cfi_interface.py
+++ b/tests/cfi/test_cfi_interface.py
@@ -1,0 +1,52 @@
+
+from luxtronik import (
+  Parameters,
+  Calculations,
+  Visibilities,
+  LuxtronikSocketInterface,
+)
+
+
+class TestLuxtronikSocketInterface:
+
+    def test_parse(self):
+        lux = LuxtronikSocketInterface('host')
+        parameters = Parameters()
+        calculations = Calculations()
+        visibilities = Visibilities()
+
+        n = 2000
+        t = list(range(0, n + 1))
+
+        lux._parse(parameters, t)
+        p = parameters.get(n)
+        assert p.name == f"unknown_parameter_{n}"
+        assert p.raw == n
+
+        lux._parse(calculations, t)
+        c = calculations.get(n)
+        assert c.name == f"unknown_calculation_{n}"
+        assert c.raw == n
+
+        lux._parse(visibilities, t)
+        v = visibilities.get(n)
+        assert v.name == f"unknown_visibility_{n}"
+        assert v.raw == n
+
+        n = 10
+        t = list(range(0, n + 1))
+
+        lux._parse(parameters, t)
+        for definition, field in parameters.data.pairs():
+            if definition.index > n:
+                assert field.raw is None
+
+        lux._parse(calculations, t)
+        for definition, field in calculations.data.pairs():
+            if definition.index > n:
+                assert field.raw is None
+
+        lux._parse(visibilities, t)
+        for definition, field in visibilities.data.pairs():
+            if definition.index > n:
+                assert field.raw is None

--- a/tests/cfi/test_cfi_parameters.py
+++ b/tests/cfi/test_cfi_parameters.py
@@ -66,19 +66,6 @@ class TestParameters:
         j = 0.0
         assert parameters._lookup(j) is None
 
-    def test_parse(self):
-        """Test cases for _parse"""
-        parameters = Parameters()
-
-        n = 2000
-        t = list(range(0, n + 1))
-        parameters.parse(t)
-
-        p = parameters.get(n)
-
-        assert p.name == f"unknown_parameter_{n}"
-        assert p.raw == n
-
     def test___iter__(self):
         """Test cases for __iter__"""
         parameters = Parameters()

--- a/tests/shi/test_shi_vector.py
+++ b/tests/shi/test_shi_vector.py
@@ -309,33 +309,6 @@ class TestDataVector:
         assert field_9.value == 6
         assert field_9.write_pending
 
-    def test_parse(self):
-        data_vector = DataVectorTest(parse_version("1.1.2"))
-        field_5 = data_vector[5]
-        field_9 = data_vector[9]
-        field_9a = data_vector['field_9a']
-
-        # not enough data
-        data = [1]
-        data_vector.parse(data)
-        assert field_5.value is None
-        assert field_9.value is None
-        assert field_9a.value is None
-
-        # data only for field 5
-        data = [1, 2, 3, 4, 5, 6, 7]
-        data_vector.parse(data)
-        assert field_5.value == 6
-        assert field_9.value is None
-        assert field_9a.value is None
-
-        # data for all fields
-        data = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2]
-        data_vector.parse(data)
-        assert field_5.value == 4
-        assert field_9.value == [0, -1]
-        assert field_9a.value == 0
-
     def test_alias(self):
         TEST_DEFINITIONS.register_alias('field_9a', 10)
         data_vector = DataVectorTest(parse_version("1.1.2"))


### PR DESCRIPTION
Only the interface itself knows the format of the read data (e.g. bits per register, number of read registers). Therefore, it should also be responsible for integrating the data into the field objects.