### PR TITLE
Add some fields as they existed in v0.3.14

### DIFF
--- a/luxtronik/cfi/calculations.py
+++ b/luxtronik/cfi/calculations.py
@@ -13,7 +13,6 @@ from luxtronik.definitions.calculations import (
 
 from luxtronik.cfi.constants import CALCULATIONS_FIELD_NAME
 from luxtronik.cfi.vector import DataVectorConfig
-from luxtronik.datatypes import Base
 
 
 LOGGER = logging.getLogger(__name__)
@@ -39,13 +38,3 @@ class Calculations(DataVectorConfig):
     def _get_firmware_version(self):
         """Get the firmware version as string like in previous versions."""
         return self.get_firmware_version().strip("\x00")
-
-    def get(self, target):
-        """Treats certain names specially. For all others, the function of the base class is called."""
-        if target == "ID_WEB_SoftStand":
-            LOGGER.debug("The name 'ID_WEB_SoftStand' is obsolete! Use 'get_firmware_version()' instead.")
-            entry = Base("ID_WEB_SoftStand")
-            entry.raw = self._get_firmware_version()
-            return entry
-        else:
-            return super().get(target)

--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -607,6 +607,20 @@ class Count(Base):
     datatype_class = "count"
 
 
+class Version(Base):
+    """Version datatype, converts from and to a Heatpump Version."""
+
+    datatype_class = "version"
+
+    concatenate_multiple_data_chunks = False
+
+    @classmethod
+    def from_heatpump(self, value):
+        if not isinstance(value, list):
+            return None
+        return "".join([chr(c) for c in value]).strip("\x00")
+
+
 class Character(Base):
     """Character datatype, converts from and to a Character."""
 

--- a/luxtronik/definitions/calculations.py
+++ b/luxtronik/definitions/calculations.py
@@ -41,6 +41,7 @@ from luxtronik.datatypes import (
     Timestamp,
     Unknown,
     MajorMinorVersion,
+    Version,
     Voltage,
 )
 
@@ -50,7 +51,6 @@ CALCULATIONS_OFFSET: Final = 0
 CALCULATIONS_DEFAULT_DATA_TYPE: Final = 'INT32'
 
 CALCULATIONS_OUTDATED = {
-    "ID_WEB_SoftStand": "get_firmware_version()"
 }
 
 CALCULATIONS_DEFINITIONS_LIST: Final = [
@@ -862,6 +862,16 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
         "writeable": False,
         "datatype": 'UINT32',
         "unit": 'enum',
+        "description": '',
+    },
+    {
+        "index": 81,
+        "count": 10,
+        "names": ['ID_WEB_SoftStand'],
+        "type": Version,
+        "writeable": False,
+        "datatype": 'UINT32',
+        "unit": '',
         "description": '',
     },
     {
@@ -2376,8 +2386,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 232,
+        "names": ['Unknown_Calculation_232'],
+        "type": Unknown,
+    },
+    {
+        "index": 232,
         "count": 1,
-        "names": ['Vapourisation_Temperature', 'Unknown_Calculation_232'],
+        "names": ['Vapourisation_Temperature'],
         "type": Celsius,
         "writeable": False,
         "datatype": 'INT32',
@@ -2386,8 +2401,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 233,
+        "names": ['Unknown_Calculation_233'],
+        "type": Unknown,
+    },
+    {
+        "index": 233,
         "count": 1,
-        "names": ['Liquefaction_Temperature', 'Unknown_Calculation_233'],
+        "names": ['Liquefaction_Temperature'],
         "type": Celsius,
         "writeable": False,
         "datatype": 'INT32',
@@ -2416,8 +2436,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 236,
+        "names": ['Unknown_Calculation_236'],
+        "type": Unknown,
+    },
+    {
+        "index": 236,
         "count": 1,
-        "names": ['ID_WEB_Freq_VD_Soll', 'Unknown_Calculation_236'],
+        "names": ['ID_WEB_Freq_VD_Soll'],
         "type": Frequency,
         "writeable": False,
         "datatype": 'UINT32',
@@ -2426,8 +2451,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 237,
+        "names": ['Unknown_Calculation_237'],
+        "type": Unknown,
+    },
+    {
+        "index": 237,
         "count": 1,
-        "names": ['ID_WEB_Freq_VD_Min', 'Unknown_Calculation_237'],
+        "names": ['ID_WEB_Freq_VD_Min'],
         "type": Frequency,
         "writeable": False,
         "datatype": 'UINT32',
@@ -2436,8 +2466,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 238,
+        "names": ['Unknown_Calculation_238'],
+        "type": Unknown,
+    },
+    {
+        "index": 238,
         "count": 1,
-        "names": ['ID_WEB_Freq_VD_Max', 'Unknown_Calculation_238'],
+        "names": ['ID_WEB_Freq_VD_Max'],
         "type": Frequency,
         "writeable": False,
         "datatype": 'UINT32',
@@ -2446,8 +2481,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 239,
+        "names": ['Unknown_Calculation_239'],
+        "type": Unknown,
+    },
+    {
+        "index": 239,
         "count": 1,
-        "names": ['VBO_Temp_Spread_Soll', 'Unknown_Calculation_239'],
+        "names": ['VBO_Temp_Spread_Soll'],
         "type": Kelvin,
         "writeable": False,
         "datatype": 'INT32',
@@ -2456,8 +2496,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 240,
+        "names": ['Unknown_Calculation_240'],
+        "type": Unknown,
+    },
+    {
+        "index": 240,
         "count": 1,
-        "names": ['VBO_Temp_Spread_Ist', 'Unknown_Calculation_240'],
+        "names": ['VBO_Temp_Spread_Ist'],
         "type": Kelvin,
         "writeable": False,
         "datatype": 'INT32',
@@ -2476,8 +2521,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 242,
+        "names": ['Unknown_Calculation_242'],
+        "type": Unknown,
+    },
+    {
+        "index": 242,
         "count": 1,
-        "names": ['HUP_Temp_Spread_Soll', 'Unknown_Calculation_242'],
+        "names": ['HUP_Temp_Spread_Soll'],
         "type": Kelvin,
         "writeable": False,
         "datatype": 'INT32',
@@ -2486,8 +2536,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 243,
+        "names": ['Unknown_Calculation_243'],
+        "type": Unknown,
+    },
+    {
+        "index": 243,
         "count": 1,
-        "names": ['HUP_Temp_Spread_Ist', 'Unknown_Calculation_243'],
+        "names": ['HUP_Temp_Spread_Ist'],
         "type": Kelvin,
         "writeable": False,
         "datatype": 'INT32',
@@ -2636,8 +2691,13 @@ CALCULATIONS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 258,
+        "names": ['Unknown_Calculation_258'],
+        "type": Unknown,
+    },
+    {
+        "index": 258,
         "count": 1,
-        "names": ['RBE_Version', 'Unknown_Calculation_258'],
+        "names": ['RBE_Version'],
         "type": MajorMinorVersion,
         "writeable": False,
         "datatype": 'UINT32',

--- a/luxtronik/definitions/parameters.py
+++ b/luxtronik/definitions/parameters.py
@@ -10919,8 +10919,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1087,
+        "names": ['Unknown_Parameter_1087'],
+        "type": Unknown,
+    },
+    {
+        "index": 1087,
         "count": 1,
-        "names": ['SILENT_MODE', 'Unknown_Parameter_1087'],
+        "names": ['SILENT_MODE'],
         "type": OnOffMode,
         "writeable": False,
         "datatype": 'UINT32',
@@ -10969,8 +10974,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1092,
+        "names": ['Unknown_Parameter_1092'],
+        "type": Unknown,
+    },
+    {
+        "index": 1092,
         "count": 1,
-        "names": ['ID_Einst_SuSilence', 'Unknown_Parameter_1092'],
+        "names": ['ID_Einst_SuSilence'],
         "type": TimerProgram,
         "writeable": False,
         "datatype": 'UINT32',
@@ -10979,8 +10989,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1093,
+        "names": ['Unknown_Parameter_1093'],
+        "type": Unknown,
+    },
+    {
+        "index": 1093,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_0', 'Unknown_Parameter_1093'],
+        "names": ['ID_Einst_SilenceTimer_0'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -10989,8 +11004,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1094,
+        "names": ['Unknown_Parameter_1094'],
+        "type": Unknown,
+    },
+    {
+        "index": 1094,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_1', 'Unknown_Parameter_1094'],
+        "names": ['ID_Einst_SilenceTimer_1'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -10999,8 +11019,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1095,
+        "names": ['Unknown_Parameter_1095'],
+        "type": Unknown,
+    },
+    {
+        "index": 1095,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_2', 'Unknown_Parameter_1095'],
+        "names": ['ID_Einst_SilenceTimer_2'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11009,8 +11034,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1096,
+        "names": ['Unknown_Parameter_1096'],
+        "type": Unknown,
+    },
+    {
+        "index": 1096,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_3', 'Unknown_Parameter_1096'],
+        "names": ['ID_Einst_SilenceTimer_3'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11019,8 +11049,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1097,
+        "names": ['Unknown_Parameter_1097'],
+        "type": Unknown,
+    },
+    {
+        "index": 1097,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_4', 'Unknown_Parameter_1097'],
+        "names": ['ID_Einst_SilenceTimer_4'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11029,8 +11064,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1098,
+        "names": ['Unknown_Parameter_1098'],
+        "type": Unknown,
+    },
+    {
+        "index": 1098,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_5', 'Unknown_Parameter_1098'],
+        "names": ['ID_Einst_SilenceTimer_5'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11039,8 +11079,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1099,
+        "names": ['Unknown_Parameter_1099'],
+        "type": Unknown,
+    },
+    {
+        "index": 1099,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_6', 'Unknown_Parameter_1099'],
+        "names": ['ID_Einst_SilenceTimer_6'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11049,8 +11094,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1100,
+        "names": ['Unknown_Parameter_1100'],
+        "type": Unknown,
+    },
+    {
+        "index": 1100,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_7', 'Unknown_Parameter_1100'],
+        "names": ['ID_Einst_SilenceTimer_7'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11059,8 +11109,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1101,
+        "names": ['Unknown_Parameter_1101'],
+        "type": Unknown,
+    },
+    {
+        "index": 1101,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_8', 'Unknown_Parameter_1101'],
+        "names": ['ID_Einst_SilenceTimer_8'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11069,8 +11124,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1102,
+        "names": ['Unknown_Parameter_1102'],
+        "type": Unknown,
+    },
+    {
+        "index": 1102,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_9', 'Unknown_Parameter_1102'],
+        "names": ['ID_Einst_SilenceTimer_9'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11079,8 +11139,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1103,
+        "names": ['Unknown_Parameter_1103'],
+        "type": Unknown,
+    },
+    {
+        "index": 1103,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_10', 'Unknown_Parameter_1103'],
+        "names": ['ID_Einst_SilenceTimer_10'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11089,8 +11154,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1104,
+        "names": ['Unknown_Parameter_1104'],
+        "type": Unknown,
+    },
+    {
+        "index": 1104,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_11', 'Unknown_Parameter_1104'],
+        "names": ['ID_Einst_SilenceTimer_11'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11099,8 +11169,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1105,
+        "names": ['Unknown_Parameter_1105'],
+        "type": Unknown,
+    },
+    {
+        "index": 1105,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_12', 'Unknown_Parameter_1105'],
+        "names": ['ID_Einst_SilenceTimer_12'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11109,8 +11184,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1106,
+        "names": ['Unknown_Parameter_1106'],
+        "type": Unknown,
+    },
+    {
+        "index": 1106,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_13', 'Unknown_Parameter_1106'],
+        "names": ['ID_Einst_SilenceTimer_13'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11119,8 +11199,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1107,
+        "names": ['Unknown_Parameter_1107'],
+        "type": Unknown,
+    },
+    {
+        "index": 1107,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_14', 'Unknown_Parameter_1107'],
+        "names": ['ID_Einst_SilenceTimer_14'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11129,8 +11214,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1108,
+        "names": ['Unknown_Parameter_1108'],
+        "type": Unknown,
+    },
+    {
+        "index": 1108,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_15', 'Unknown_Parameter_1108'],
+        "names": ['ID_Einst_SilenceTimer_15'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11139,8 +11229,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1109,
+        "names": ['Unknown_Parameter_1109'],
+        "type": Unknown,
+    },
+    {
+        "index": 1109,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_16', 'Unknown_Parameter_1109'],
+        "names": ['ID_Einst_SilenceTimer_16'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11149,8 +11244,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1110,
+        "names": ['Unknown_Parameter_1110'],
+        "type": Unknown,
+    },
+    {
+        "index": 1110,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_17', 'Unknown_Parameter_1110'],
+        "names": ['ID_Einst_SilenceTimer_17'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11159,8 +11259,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1111,
+        "names": ['Unknown_Parameter_1111'],
+        "type": Unknown,
+    },
+    {
+        "index": 1111,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_18', 'Unknown_Parameter_1111'],
+        "names": ['ID_Einst_SilenceTimer_18'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11169,8 +11274,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1112,
+        "names": ['Unknown_Parameter_1112'],
+        "type": Unknown,
+    },
+    {
+        "index": 1112,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_19', 'Unknown_Parameter_1112'],
+        "names": ['ID_Einst_SilenceTimer_19'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11179,8 +11289,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1113,
+        "names": ['Unknown_Parameter_1113'],
+        "type": Unknown,
+    },
+    {
+        "index": 1113,
         "count": 1,
-        "names": ['ID_Einst_SilenceTimer_20', 'Unknown_Parameter_1113'],
+        "names": ['ID_Einst_SilenceTimer_20'],
         "type": TimeOfDay2,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11239,8 +11354,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1119,
+        "names": ['Unknown_Parameter_1119'],
+        "type": Unknown,
+    },
+    {
+        "index": 1119,
         "count": 1,
-        "names": ['LAST_DEFROST_TIMESTAMP', 'Unknown_Parameter_1119'],
+        "names": ['LAST_DEFROST_TIMESTAMP'],
         "type": Timestamp,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11409,8 +11529,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1136,
+        "names": ['Unknown_Parameter_1136'],
+        "type": Unknown,
+    },
+    {
+        "index": 1136,
         "count": 1,
-        "names": ['HEAT_ENERGY_INPUT', 'Unknown_Parameter_1136'],
+        "names": ['HEAT_ENERGY_INPUT'],
         "type": Energy,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11419,8 +11544,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1137,
+        "names": ['Unknown_Parameter_1137'],
+        "type": Unknown,
+    },
+    {
+        "index": 1137,
         "count": 1,
-        "names": ['DHW_ENERGY_INPUT', 'Unknown_Parameter_1137'],
+        "names": ['DHW_ENERGY_INPUT'],
         "type": Energy,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11439,8 +11569,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1139,
+        "names": ['Unknown_Parameter_1139'],
+        "type": Unknown,
+    },
+    {
+        "index": 1139,
         "count": 1,
-        "names": ['COOLING_ENERGY_INPUT', 'Unknown_Parameter_1139'],
+        "names": ['COOLING_ENERGY_INPUT'],
         "type": Energy,
         "writeable": False,
         "datatype": 'UINT32',
@@ -11529,8 +11664,13 @@ PARAMETERS_DEFINITIONS_LIST: Final = [
     },
     {
         "index": 1148,
+        "names": ['Unknown_Parameter_1148'],
+        "type": Unknown,
+    },
+    {
+        "index": 1148,
         "count": 1,
-        "names": ['HEATING_TARGET_TEMP_ROOM_THERMOSTAT', 'Unknown_Parameter_1148'],
+        "names": ['HEATING_TARGET_TEMP_ROOM_THERMOSTAT'],
         "type": Celsius,
         "writeable": True,
         "datatype": 'INT32',

--- a/tests/test_LuxtronikData.py
+++ b/tests/test_LuxtronikData.py
@@ -61,13 +61,14 @@ class TestLuxtronikData:
         assert a.get_firmware_version() == "V3.1"
 
         # Test of downward compatibility with outdated entry name
+        a.calculations.get("ID_WEB_SoftStand").raw = [ord("V"), ord("3"), ord("."), ord("1"), 0x00]
         assert a.calculations.get("ID_WEB_SoftStand").value == "V3.1"
 
 
     @pytest.mark.parametrize("vector, index, names", [
-        ("para", 1106, ["ID_Einst_SilenceTimer_13", "Unknown_Parameter_1106"]),
-        ("para", 1109, ["ID_Einst_SilenceTimer_16", "Unknown_Parameter_1109"]),
-        ("calc", 232, ["Vapourisation_Temperature", "Unknown_Calculation_232"]),
+        ("para", 1106, ["ID_Einst_SilenceTimer_13"]),
+        ("para", 1109, ["ID_Einst_SilenceTimer_16"]),
+        ("calc", 232, ["Vapourisation_Temperature"]),
         ("calc", 241, ["HUP_PWM", "Circulation_Pump"]),
         ("visi", 182, ["ID_Visi_Heizung_Zeitschaltprogramm", "ID_Visi_Heizung_Zeitschlaltprogramm"]),
         ("visi", 326, ["Unknown_Visibility_326"]),

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1293,6 +1293,7 @@ class TestCompatibility:
             "ID_WEB_Code_WP_akt": 78,
             "ID_WEB_BIV_Stufe_akt": 79,
             "ID_WEB_WP_BZ_akt": 80,
+            "ID_WEB_SoftStand": 81,
             "ID_WEB_AdresseIP_akt": 91,
             "ID_WEB_SubNetMask_akt": 92,
             "ID_WEB_Add_Broadcast": 93,
@@ -1494,7 +1495,6 @@ class TestCompatibility:
             "Desired_Room_Temperature": 267,
             "AC_Power_Input": 268,
         }
-        # Note: "ID_WEB_SoftStand" tested in "test_get_firmware_version()"
 
         visis = {
             # Status of 0.3.14:

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -54,6 +54,7 @@ from luxtronik.datatypes import (
     TimerProgram,
     TimeOfDay,
     TimeOfDay2,
+    Version,
 )
 
 
@@ -934,6 +935,24 @@ class TestCount:
         assert a.name == "count"
         assert a.datatype_class == "count"
         assert a.datatype_unit is None
+
+
+class TestVersion:
+    """Test suite for Version datatype"""
+
+    def test_init(self):
+        """Test cases for initialization"""
+
+        a = Version("ver")
+        assert a.name == "ver"
+        assert a.datatype_class == "version"
+        assert a.datatype_unit is None
+
+    def test_from_heatpump(self):
+
+        assert Version.from_heatpump([3, 1, 4]) == '\x03\x01\x04'
+        assert Version.from_heatpump(None) is None
+        assert Version.from_heatpump("a") is None
 
 
 class TestCharacter:


### PR DESCRIPTION
In version v0.3.14, there were several unknown_fields of the `unknown` data type. These were only changed later, both in name and data type. This is now divided into two different fields: the old one as `unknown` and the new one with the current data type.